### PR TITLE
[add] ExRabbitPool.Consumer macro with default consumer implementation

### DIFF
--- a/examples/echo_consumer.ex
+++ b/examples/echo_consumer.ex
@@ -1,157 +1,37 @@
 defmodule Example.EchoConsumer do
-  use GenServer
+  use ExRabbitPool.Consumer
 
   require Logger
-
-  defmodule State do
-    @moduledoc """
-    RabbitMQ Consumer Worker State.
-
-    State attributes:
-
-      * `:pool_id` - the name of the connection pool to RabbitMQ
-      * `:channel` - the RabbitMQ channel for consuming new messages
-      * `:monitor` - a monitor for handling channel crashes
-      * `:queue` - the name of the queue to consume
-      * `:consumer_tag` - the consumer tag assigned by RabbitMQ
-      * `:config` - the consumer configuration attributes
-      * `:adapter` - the RabbitMQ client to use
-    """
-    @enforce_keys [:pool_id]
-
-    @typedoc "Consumer State Type"
-    @type t :: %__MODULE__{
-            pool_id: atom(),
-            channel: AMQP.Channel.t(),
-            monitor: reference(),
-            queue: String.t(),
-            consumer_tag: String.t(),
-            config: keyword(),
-            adapter: module()
-          }
-    defstruct pool_id: nil,
-              caller: nil,
-              channel: nil,
-              monitor: nil,
-              queue: nil,
-              consumer_tag: nil,
-              config: [],
-              adapter: nil
-  end
-
-  def start_link(config) do
-    GenServer.start_link(__MODULE__, config)
-  end
-
-  ####################
-  # Server Callbacks #
-  ####################
-
-  @impl true
-  def init(config) do
-    {opts, consumer_config} = Keyword.split(config, [:adapter, :pool_id, :queue])
-    adapter = Keyword.get(opts, :adapter, ExRabbitPool.RabbitMQ)
-    pool_id = Keyword.fetch!(opts, :pool_id)
-    queue = Keyword.fetch!(opts, :queue)
-    send(self(), :connect)
-
-    {:ok,
-     %State{
-       pool_id: pool_id,
-       queue: queue,
-       adapter: adapter,
-       config: consumer_config
-     }}
-  end
-
-  # Gets a connection worker out of the connection pool, if there is one available
-  # takes a channel out of it channel pool, if there is one available subscribe
-  # itself as a consumer process.
-  @impl true
-  def handle_info(:connect, %{pool_id: pool_id} = state) do
-    pool_id
-    |> ExRabbitPool.get_connection_worker()
-    |> ExRabbitPool.checkout_channel()
-    |> handle_channel_checkout(state)
-  end
-
-  @impl true
-  def handle_info(
-        {:DOWN, monitor, :process, chan_pid, reason},
-        %{monitor: monitor, channel: %{pid: chan_pid}} = state
-      ) do
-    Logger.error("[consumer] channel down reason: #{inspect(reason)}")
-    schedule_connect()
-    {:noreply, %State{state | monitor: nil, consumer_tag: nil, channel: nil}}
-  end
 
   ################################
   # AMQP Basic.Consume Callbacks #
   ################################
 
   # Confirmation sent by the broker after registering this process as a consumer
-  @impl true
-  def handle_info({:basic_consume_ok, %{consumer_tag: _consumer_tag}}, state) do
+  def basic_consume_ok(_adapter, _channel, _consumer_tag) do
     Logger.info("[consumer] successfully registered as a consumer (basic_consume_ok)")
-    {:noreply, state}
+    :ok
   end
 
   # This is sent for each message consumed, where `payload` contains the message
   # content and `meta` contains all the metadata set when sending with
   # Basic.publish or additional info set by the broker;
-  @impl true
-  def handle_info(
-        {:basic_deliver, payload, %{delivery_tag: delivery_tag}},
-        %{channel: channel, adapter: adapter} = state
-      ) do
+  def basic_deliver(adapter, channel, payload, %{delivery_tag: delivery_tag}) do
     Logger.info("[consumer] consuming payload (#{inspect payload})")
     :ok = adapter.ack(channel, delivery_tag, requeue: false)
-    {:noreply, state}
+    :ok
   end
 
   # Sent by the broker when the consumer is unexpectedly cancelled (such as after a queue deletion)
-  @impl true
-  def handle_info({:basic_cancel, %{consumer_tag: _consumer_tag}}, state) do
+  def basic_cancel(_adapter, _channel, _consumer_tag, _no_wait) do
     Logger.error("[consumer] consumer was cancelled by the broker (basic_cancel)")
-    {:stop, :normal, %State{state | channel: nil}}
+    :ok
   end
 
   # Confirmation sent by the broker to the consumer process after a Basic.cancel
-  @impl true
-  def handle_info({:basic_cancel_ok, %{consumer_tag: _consumer_tag}}, state) do
+  def basic_cancel_ok(_adapter, _channel, _consumer_tag) do
     Logger.error("[consumer] consumer was cancelled by the broker (basic_cancel_ok)")
-    {:stop, :normal, %State{state | channel: nil}}
-  end
-
-  # When successfully checks out a channel, subscribe itself as a consumer
-  # process and monitors it handle crashes and reconnections
-  defp handle_channel_checkout(
-         {:ok, %{pid: channel_pid} = channel},
-         %{config: config, queue: queue, adapter: adapter} = state
-       ) do
-    config = Keyword.get(config, :options, [])
-
-    case adapter.consume(channel, queue, self(), config) do
-      {:ok, consumer_tag} ->
-        ref = Process.monitor(channel_pid)
-        {:noreply, %State{state | channel: channel, monitor: ref, consumer_tag: consumer_tag}}
-
-      {:error, reason} ->
-        Logger.error("[consumer] error consuming channel reason: #{inspect(reason)}")
-        schedule_connect()
-        {:noreply, %State{state | channel: nil, consumer_tag: nil}}
-    end
-  end
-
-  # When there was an error checking out a channel, retry in a configured interval
-  defp handle_channel_checkout({:error, reason}, state) do
-    Logger.error("[consumer] error getting channel reason: #{inspect(reason)}")
-    schedule_connect()
-    {:noreply, state}
-  end
-
-  defp schedule_connect do
-    Process.send_after(self(), :connect, 1000)
+    :ok
   end
 end
 

--- a/lib/clients/adapter.ex
+++ b/lib/clients/adapter.ex
@@ -1,11 +1,14 @@
 defmodule ExRabbitPool.Clients.Adapter do
   @callback open_connection(keyword() | String.t()) :: {:ok, AMQP.Connection.t()} | {:error, any}
   @callback open_channel(AMQP.Connection.t()) :: {:ok, AMQP.Channel.t()} | {:error, any()} | any()
+  @callback close_channel(AMQP.Channel.t()) :: :ok | {:error, AMQP.Basic.error()}
   @callback close_connection(AMQP.Connection.t()) :: :ok | {:error, any}
   @callback publish(AMQP.Channel.t(), String.t(), String.t(), String.t(), keyword) ::
               :ok | AMQP.Basic.error()
   @callback consume(AMQP.Channel.t(), String.t(), pid() | nil, keyword) ::
               {:ok, String.t()} | AMQP.Basic.error()
+  @callback cancel_consume(AMQP.Channel.t(), String.t(), keyword) ::
+              {:ok, String.t()} | {:error, AMQP.Basic.error()}
   @callback ack(AMQP.Channel.t(), String.t(), keyword()) :: :ok | AMQP.Basic.error()
   @callback reject(AMQP.Channel.t(), String.t(), keyword()) :: :ok | AMQP.Basic.error()
   @callback declare_queue(AMQP.Channel.t(), AMQP.Basic.queue(), keyword()) ::

--- a/lib/clients/fake_rabbitmq.ex
+++ b/lib/clients/fake_rabbitmq.ex
@@ -38,26 +38,22 @@ defmodule ExRabbitPool.FakeRabbitMQ do
     if Keyword.get(config, :queue) == "error.queue" do
       {:error, :invalid}
     else
-      # Connection.open(config)
       {:ok, %Connection{pid: self()}}
     end
   end
 
   @impl true
   def open_channel(conn) do
-    # Channel.open(conn)
     {:ok, %Channel{conn: conn, pid: self()}}
   end
 
   @impl true
   def close_channel(_channel) do
-    # Channel.close(channel)
     :ok
   end
 
   @impl true
   def close_connection(_conn) do
-    #  Connection.close(conn)
     :ok
   end
 

--- a/lib/clients/fake_rabbitmq.ex
+++ b/lib/clients/fake_rabbitmq.ex
@@ -19,6 +19,11 @@ defmodule ExRabbitPool.FakeRabbitMQ do
   end
 
   @impl true
+  def cancel_consume(_channel, consumer_tag, _options \\ []) do
+    {:ok, consumer_tag}
+  end
+
+  @impl true
   def ack(_channel, _tag, _options \\ []) do
     :ok
   end
@@ -42,6 +47,12 @@ defmodule ExRabbitPool.FakeRabbitMQ do
   def open_channel(conn) do
     # Channel.open(conn)
     {:ok, %Channel{conn: conn, pid: self()}}
+  end
+
+  @impl true
+  def close_channel(_channel) do
+    # Channel.close(channel)
+    :ok
   end
 
   @impl true

--- a/lib/clients/rabbitmq.ex
+++ b/lib/clients/rabbitmq.ex
@@ -16,6 +16,11 @@ defmodule ExRabbitPool.RabbitMQ do
   end
 
   @impl true
+  def cancel_consume(%Channel{} = channel, consumer_tag, options \\ []) do
+    Basic.cancel(channel, consumer_tag, options)
+  end
+
+  @impl true
   def ack(%Channel{} = channel, tag, options \\ []) do
     Basic.ack(channel, tag, options)
   end
@@ -33,6 +38,11 @@ defmodule ExRabbitPool.RabbitMQ do
   @impl true
   def open_channel(conn) do
     Channel.open(conn)
+  end
+
+  @impl true
+  def close_channel(channel) do
+    Channel.close(channel)
   end
 
   @impl true

--- a/lib/consumer.ex
+++ b/lib/consumer.ex
@@ -1,0 +1,210 @@
+defmodule ExRabbitPool.Consumer do
+  defmodule State do
+    @moduledoc """
+    RabbitMQ Consumer Worker State.
+
+    State attributes:
+
+      * `:pool_id` - the name of the connection pool to RabbitMQ
+      * `:channel` - the RabbitMQ channel for consuming new messages
+      * `:monitor` - a monitor for handling channel crashes
+      * `:queue` - the name of the queue to consume
+      * `:consumer_tag` - the consumer tag assigned by RabbitMQ
+      * `:config` - the consumer configuration attributes
+      * `:adapter` - the RabbitMQ client to use
+    """
+    @enforce_keys [:pool_id, :queue]
+
+    @typedoc "Consumer State Type"
+    @type t :: %__MODULE__{
+            pool_id: atom(),
+            channel: AMQP.Channel.t(),
+            monitor: reference(),
+            queue: AMQP.Basic.queue(),
+            consumer_tag: AMQP.Basic.consumer_tag(),
+            config: keyword(),
+            adapter: module()
+          }
+    defstruct pool_id: nil,
+              caller: nil,
+              channel: nil,
+              monitor: nil,
+              queue: nil,
+              consumer_tag: nil,
+              config: [],
+              adapter: nil
+  end
+
+  @type meta :: map()
+  @type no_wait :: boolean()
+  @type reason :: any()
+
+  @callback basic_consume_ok(module(), AMQP.Channel.t(), AMQP.Basic.consumer_tag()) ::
+              :ok | {:stop, reason}
+  @callback basic_deliver(module(), AMQP.Channel.t(), AMQP.Basic.payload(), meta()) ::
+              :ok | {:stop, reason}
+  @callback basic_cancel(module(), AMQP.Channel.t(), AMQP.Basic.consumer_tag(), no_wait) ::
+              :ok | {:stop, reason}
+  @callback basic_cancel_ok(module(), AMQP.Channel.t(), AMQP.Basic.consumer_tag()) ::
+              :ok | {:stop, reason}
+
+  defmacro __using__(_opts) do
+    quote do
+      use GenServer
+
+      def child_spec(config) do
+        %{
+          id: __MODULE__,
+          start: {__MODULE__, :start_link, [config]},
+          type: :supervisor
+        }
+      end
+
+      def start_link(config) do
+        GenServer.start_link(__MODULE__, config)
+      end
+
+      ####################
+      # Server Callbacks #
+      ####################
+
+      @impl true
+      def init(config) do
+        {opts, consumer_config} = Keyword.split(config, [:adapter, :pool_id, :queue])
+        adapter = Keyword.get(opts, :adapter, ExRabbitPool.RabbitMQ)
+        pool_id = Keyword.fetch!(opts, :pool_id)
+        queue = Keyword.fetch!(opts, :queue)
+        send(self(), :connect)
+
+        {:ok,
+         %State{
+           pool_id: pool_id,
+           queue: queue,
+           adapter: adapter,
+           config: consumer_config
+         }}
+      end
+
+      # Gets a connection worker out of the connection pool, if there is one available
+      # takes a channel out of it channel pool, if there is one available subscribe
+      # itself as a consumer process.
+      @impl true
+      def handle_info(:connect, %{pool_id: pool_id} = state) do
+        pool_id
+        |> ExRabbitPool.get_connection_worker()
+        |> ExRabbitPool.checkout_channel()
+        |> handle_channel_checkout(state)
+      end
+
+      @impl true
+      def handle_info(
+            {:DOWN, monitor, :process, chan_pid, reason},
+            %{monitor: monitor, channel: %{pid: chan_pid}} = state
+          ) do
+        schedule_connect()
+        {:noreply, %State{state | monitor: nil, consumer_tag: nil, channel: nil}}
+      end
+
+      ################################
+      # AMQP Basic.Consume Callbacks #
+      ################################
+
+      # Confirmation sent by the broker after registering this process as a consumer
+      @impl true
+      def handle_info(
+            {:basic_consume_ok, %{consumer_tag: consumer_tag}},
+            %State{adapter: adapter, channel: channel} = state
+          ) do
+        case basic_consume_ok(adapter, channel, consumer_tag) do
+          :ok ->
+            {:noreply, state}
+
+          {:stop, reason} ->
+            {:stop, reason, state}
+
+          _ ->
+            {:noreply, state}
+        end
+      end
+
+      # This is sent for each message consumed, where `payload` contains the message
+      # content and `meta` contains all the metadata set when sending with
+      # Basic.publish or additional info set by the broker;
+      @impl true
+      def handle_info(
+            {:basic_deliver, payload, meta},
+            %State{adapter: adapter, channel: channel} = state
+          ) do
+        case basic_deliver(adapter, channel, payload, meta) do
+          :ok ->
+            {:noreply, state}
+
+          {:stop, reason} ->
+            {:stop, reason, state}
+
+          _ ->
+            {:noreply, state}
+        end
+      end
+
+      # Sent by the broker when the consumer is unexpectedly cancelled (such as after a queue deletion)
+      @impl true
+      def handle_info(
+            {:basic_cancel, %{consumer_tag: consumer_tag, no_wait: no_wait}},
+            %State{adapter: adapter, channel: channel} = state
+          ) do
+        case basic_cancel(adapter, channel, consumer_tag, no_wait) do
+          :ok ->
+            {:stop, :shutdown, state}
+
+          {:stop, reason} ->
+            {:stop, reason, state}
+        end
+      end
+
+      # Confirmation sent by the broker to the consumer process after a Basic.cancel
+      @impl true
+      def handle_info(
+            {:basic_cancel_ok, %{consumer_tag: consumer_tag}},
+            %State{adapter: adapter, channel: channel} = state
+          ) do
+        case basic_cancel_ok(adapter, channel, consumer_tag) do
+          :ok ->
+            {:stop, :normal, state}
+
+          {:stop, reason} ->
+            {:stop, reason, state}
+        end
+      end
+
+      # When successfully checks out a channel, subscribe itself as a consumer
+      # process and monitors it handle crashes and reconnections
+      defp handle_channel_checkout(
+             {:ok, %{pid: channel_pid} = channel},
+             %{config: config, queue: queue, adapter: adapter} = state
+           ) do
+        config = Keyword.get(config, :options, [])
+
+        case adapter.consume(channel, queue, self(), config) do
+          {:ok, consumer_tag} ->
+            ref = Process.monitor(channel_pid)
+            {:noreply, %State{state | channel: channel, monitor: ref, consumer_tag: consumer_tag}}
+
+          {:error, reason} ->
+            schedule_connect()
+            {:noreply, %State{state | channel: nil, consumer_tag: nil}}
+        end
+      end
+
+      # When there was an error checking out a channel, retry in a configured interval
+      defp handle_channel_checkout({:error, reason}, state) do
+        schedule_connect()
+        {:noreply, state}
+      end
+
+      defp schedule_connect do
+        Process.send_after(self(), :connect, 1000)
+      end
+    end
+  end
+end

--- a/lib/consumer.ex
+++ b/lib/consumer.ex
@@ -191,6 +191,13 @@ defmodule ExRabbitPool.Consumer do
         reconnect_interval = Keyword.get(config, :reconnect_interval, 1_000)
         Process.send_after(self(), :connect, reconnect_interval)
       end
+
+      def basic_deliver(%{adapter: adapter, channel: channel}, payload, %{delivery_tag: tag}) do
+        :ok = adapter.ack(channel, tag)
+        IO.puts(payload)
+      end
+
+      defoverridable basic_deliver: 3
     end
   end
 end

--- a/lib/consumer.ex
+++ b/lib/consumer.ex
@@ -196,6 +196,7 @@ defmodule ExRabbitPool.Consumer do
         :ok = adapter.ack(channel, tag)
         IO.puts("[*] RabbitMQ message received: #{payload}")
       end
+
       def basic_consume_ok(_state, _consumer_tag), do: :ok
       def basic_cancel(_state, _consumer_tag, _no_wait), do: :ok
       def basic_cancel_ok(_state, _consumer_tag), do: :ok

--- a/lib/consumer.ex
+++ b/lib/consumer.ex
@@ -194,10 +194,16 @@ defmodule ExRabbitPool.Consumer do
 
       def basic_deliver(%{adapter: adapter, channel: channel}, payload, %{delivery_tag: tag}) do
         :ok = adapter.ack(channel, tag)
-        IO.puts(payload)
+        IO.puts("[*] RabbitMQ message received: #{payload}")
       end
+      def basic_consume_ok(_state, _consumer_tag), do: :ok
+      def basic_cancel(_state, _consumer_tag, _no_wait), do: :ok
+      def basic_cancel_ok(_state, _consumer_tag), do: :ok
 
       defoverridable basic_deliver: 3
+      defoverridable basic_consume_ok: 2
+      defoverridable basic_cancel: 3
+      defoverridable basic_cancel_ok: 2
     end
   end
 end

--- a/lib/pool_supervisor.ex
+++ b/lib/pool_supervisor.ex
@@ -25,7 +25,9 @@ defmodule ExRabbitPool.PoolSupervisor do
         rabbitmq_conn_pool ->
           rabbitmq_config = Keyword.get(config, :rabbitmq_config, [])
           {_, pool_id} = Keyword.fetch!(rabbitmq_conn_pool, :name)
-
+          # We are using poolboy's pool as a fifo queue so we can distribute the
+          # load between workers
+          rabbitmq_conn_pool = Keyword.merge(rabbitmq_conn_pool, strategy: :fifo)
           [
             :poolboy.child_spec(pool_id, rabbitmq_conn_pool, rabbitmq_config),
             {SetupQueue, {pool_id, rabbitmq_config}}

--- a/lib/worker/rabbit_connection.ex
+++ b/lib/worker/rabbit_connection.ex
@@ -4,7 +4,7 @@ defmodule ExRabbitPool.Worker.RabbitConnection do
   require Logger
 
   @reconnect_interval 1_000
-  @default_channels 1_000
+  @default_channels 10
 
   defmodule State do
     @type config :: keyword() | String.t()

--- a/test/integration/api_test.exs
+++ b/test/integration/api_test.exs
@@ -27,7 +27,6 @@ defmodule ExRabbitPool.Integration.ApiTest do
     ]
 
     rabbitmq_conn_pool = [
-      :rabbitmq_conn_pool,
       name: {:local, pool_id},
       worker_module: RabbitConnection,
       size: 1,

--- a/test/integration/consumer_test.exs
+++ b/test/integration/consumer_test.exs
@@ -19,14 +19,8 @@ defmodule ExRabbitPool.ConsumerTest do
     def basic_cancel_ok(_state, _consumer_tag), do: :ok
   end
 
-  defmodule TestConsumerDefaultDeliver do
+  defmodule TestDefaultConsumer do
     use ExRabbitPool.Consumer
-
-    def basic_consume_ok(_state, _consumer_tag), do: :ok
-
-    def basic_cancel(_state, _consumer_tag, _no_wait), do: :ok
-
-    def basic_cancel_ok(_state, _consumer_tag), do: :ok
   end
 
   defp random_queue_name() do
@@ -110,8 +104,11 @@ defmodule ExRabbitPool.ConsumerTest do
   end
 
   @tag capture_io: true
-  test "should be able to consume messages out of rabbitmq with default consumer", %{pool_id: pool_id, queue: queue} do
-    start_supervised!({TestConsumerDefaultDeliver, pool_id: pool_id, queue: queue})
+  test "should be able to consume messages out of rabbitmq with default consumer", %{
+    pool_id: pool_id,
+    queue: queue
+  } do
+    start_supervised!({TestDefaultConsumer, pool_id: pool_id, queue: queue})
 
     ExRabbitPool.with_channel(pool_id, fn {:ok, channel} ->
       assert :ok = AMQP.Basic.publish(channel, "#{queue}_exchange", "", "Hello Consumer!")

--- a/test/integration/consumer_test.exs
+++ b/test/integration/consumer_test.exs
@@ -1,0 +1,109 @@
+defmodule ExRabbitPool.ConsumerTest do
+  use ExUnit.Case, async: false
+
+  alias ExRabbitPool.Worker.SetupQueue
+
+  @moduletag :integration
+
+  defmodule TestConsumer do
+    use ExRabbitPool.Consumer
+
+    require Logger
+
+    def basic_consume_ok(_state, _consumer_tag) do
+      :ok
+    end
+
+    def basic_deliver(%{adapter: adapter, channel: channel}, _payload, %{delivery_tag: tag}) do
+      :ok = adapter.ack(channel, tag)
+    end
+
+    def basic_cancel(_state, _consumer_tag, _no_wait) do
+      Logger.error("basic cancel called")
+      :ok
+    end
+
+    def basic_cancel_ok(_state, _consumer_tag) do
+      :ok
+    end
+  end
+
+  defp random_queue_name() do
+    rnd =
+      8
+      |> :crypto.strong_rand_bytes()
+      |> Base.url_encode64()
+      |> binary_part(0, 8)
+
+    "test.queue-" <> rnd
+  end
+
+  defp wait_for(timeout \\ 1000, f)
+  defp wait_for(0, _), do: {:error, "Error - Timeout"}
+
+  defp wait_for(timeout, f) do
+    if f.() do
+      :ok
+    else
+      :timer.sleep(10)
+      wait_for(timeout - 10, f)
+    end
+  end
+
+  setup do
+    queue = random_queue_name()
+
+    rabbitmq_config = [
+      channels: 2,
+      port: String.to_integer(System.get_env("EX_RABBIT_POOL_PORT") || "5672")
+    ]
+
+    rabbitmq_conn_pool = [
+      name: {:local, :setup_queue_pool},
+      worker_module: ExRabbitPool.Worker.RabbitConnection,
+      size: 1,
+      max_overflow: 0
+    ]
+
+    start_supervised!(%{
+      id: ExRabbitPool.PoolSupervisorTest,
+      start:
+        {ExRabbitPool.PoolSupervisor, :start_link,
+         [
+           [rabbitmq_config: rabbitmq_config, rabbitmq_conn_pool: rabbitmq_conn_pool],
+           ExRabbitPool.PoolSupervisorTest
+         ]},
+      type: :supervisor
+    })
+
+    start_supervised!(
+      {SetupQueue,
+       {:setup_queue_pool,
+        [
+          queues: [
+            [
+              queue_name: queue,
+              exchange: "#{queue}_exchange",
+              queue_options: [auto_delete: true],
+              exchange_options: [auto_delete: true]
+            ]
+          ]
+        ]}}
+    )
+
+    {:ok, pool_id: :setup_queue_pool, queue: queue}
+  end
+
+  test "should be able to consume messages out of rabbitmq", %{pool_id: pool_id, queue: queue} do
+    start_supervised!({TestConsumer, pool_id: pool_id, queue: queue})
+
+    ExRabbitPool.with_channel(pool_id, fn {:ok, channel} ->
+      assert :ok = AMQP.Basic.publish(channel, "#{queue}_exchange", "", "Hello Consumer!")
+
+      wait_for(fn ->
+        {:ok, result} = AMQP.Queue.status(channel, queue)
+        result == %{consumer_count: 1, message_count: 0, queue: queue}
+      end)
+    end)
+  end
+end

--- a/test/integration/setup_queue_test.exs
+++ b/test/integration/setup_queue_test.exs
@@ -25,7 +25,6 @@ defmodule ExRabbitPool.Integration.SetupQueueTest do
     ]
 
     rabbitmq_conn_pool = [
-      :rabbitmq_conn_pool,
       name: {:local, :setup_queue_pool},
       worker_module: ExRabbitPool.Worker.RabbitConnection,
       size: 1,

--- a/test/integration/setup_queue_test.exs
+++ b/test/integration/setup_queue_test.exs
@@ -2,6 +2,8 @@ defmodule ExRabbitPool.Integration.SetupQueueTest do
   use ExUnit.Case
 
   alias ExRabbitPool.Worker.SetupQueue
+  alias ExRabbitPool.RabbitMQ
+  alias AMQP.{Basic, Queue}
 
   @moduletag :integration
 
@@ -68,14 +70,14 @@ defmodule ExRabbitPool.Integration.SetupQueueTest do
     )
 
     ExRabbitPool.with_channel(pool_id, fn {:ok, channel} ->
-      assert :ok = AMQP.Basic.publish(channel, "#{queue1}_exchange", "", "Hello, World!")
-      assert {:ok, "Hello, World!", _meta} = AMQP.Basic.get(channel, queue1, no_ack: true)
+      assert :ok = RabbitMQ.publish(channel, "#{queue1}_exchange", "", "Hello, World!")
+      assert {:ok, "Hello, World!", _meta} = Basic.get(channel, queue1, no_ack: true)
 
-      assert :ok = AMQP.Basic.publish(channel, "#{queue2}_exchange", "", "Hell Yeah!")
-      assert {:ok, "Hell Yeah!", _meta} = AMQP.Basic.get(channel, queue2, no_ack: true)
+      assert :ok = RabbitMQ.publish(channel, "#{queue2}_exchange", "", "Hell Yeah!")
+      assert {:ok, "Hell Yeah!", _meta} = Basic.get(channel, queue2, no_ack: true)
 
-      assert {:ok, _} = AMQP.Queue.delete(channel, queue1)
-      assert {:ok, _} = AMQP.Queue.delete(channel, queue2)
+      assert {:ok, _} = Queue.delete(channel, queue1)
+      assert {:ok, _} = Queue.delete(channel, queue2)
     end)
   end
 
@@ -115,17 +117,17 @@ defmodule ExRabbitPool.Integration.SetupQueueTest do
     )
 
     ExRabbitPool.with_channel(pool_id, fn {:ok, channel} ->
-      assert :ok = AMQP.Basic.publish(channel, "X", "orange", "Hello, World!")
-      assert {:ok, "Hello, World!", _meta} = AMQP.Basic.get(channel, queue1, no_ack: true)
+      assert :ok = RabbitMQ.publish(channel, "X", "orange", "Hello, World!")
+      assert {:ok, "Hello, World!", _meta} = Basic.get(channel, queue1, no_ack: true)
 
-      assert :ok = AMQP.Basic.publish(channel, "X", "black", "Hola Mundo!")
-      assert {:ok, "Hola Mundo!", _meta} = AMQP.Basic.get(channel, queue2, no_ack: true)
+      assert :ok = RabbitMQ.publish(channel, "X", "black", "Hola Mundo!")
+      assert {:ok, "Hola Mundo!", _meta} = Basic.get(channel, queue2, no_ack: true)
 
-      assert :ok = AMQP.Basic.publish(channel, "X", "green", "Olá Mundo!")
-      assert {:ok, "Olá Mundo!", _meta} = AMQP.Basic.get(channel, queue2, no_ack: true)
+      assert :ok = RabbitMQ.publish(channel, "X", "green", "Olá Mundo!")
+      assert {:ok, "Olá Mundo!", _meta} = Basic.get(channel, queue2, no_ack: true)
 
-      assert {:ok, _} = AMQP.Queue.delete(channel, queue1)
-      assert {:ok, _} = AMQP.Queue.delete(channel, queue2)
+      assert {:ok, _} = Queue.delete(channel, queue1)
+      assert {:ok, _} = Queue.delete(channel, queue2)
     end)
   end
 
@@ -152,11 +154,11 @@ defmodule ExRabbitPool.Integration.SetupQueueTest do
     )
 
     ExRabbitPool.with_channel(pool_id, fn {:ok, channel} ->
-      assert :ok = AMQP.Basic.publish(channel, "#{queue1}_exchange", "", "Hello, World!")
-      assert {:ok, "Hello, World!", _meta} = AMQP.Basic.get(channel, queue1, no_ack: true)
-      assert {:ok, "Hello, World!", _meta} = AMQP.Basic.get(channel, queue2, no_ack: true)
-      assert {:ok, _} = AMQP.Queue.delete(channel, queue1)
-      assert {:ok, _} = AMQP.Queue.delete(channel, queue2)
+      assert :ok = RabbitMQ.publish(channel, "#{queue1}_exchange", "", "Hello, World!")
+      assert {:ok, "Hello, World!", _meta} = Basic.get(channel, queue1, no_ack: true)
+      assert {:ok, "Hello, World!", _meta} = Basic.get(channel, queue2, no_ack: true)
+      assert {:ok, _} = Queue.delete(channel, queue1)
+      assert {:ok, _} = Queue.delete(channel, queue2)
     end)
   end
 end

--- a/test/integration/setup_queue_test.exs
+++ b/test/integration/setup_queue_test.exs
@@ -1,5 +1,5 @@
 defmodule ExRabbitPool.Integration.SetupQueueTest do
-  use ExUnit.Case, async: false
+  use ExUnit.Case
 
   alias ExRabbitPool.Worker.SetupQueue
 
@@ -54,13 +54,13 @@ defmodule ExRabbitPool.Integration.SetupQueueTest do
           queues: [
             [
               queue_name: queue1,
-              exchange: "my_exchange",
+              exchange: "#{queue1}_exchange",
               queue_options: [auto_delete: true],
               exchange_options: [auto_delete: true]
             ],
             [
               queue_name: queue2,
-              exchange: "my_exchange2",
+              exchange: "#{queue2}_exchange",
               queue_options: [auto_delete: true],
               exchange_options: [auto_delete: true]
             ]
@@ -69,10 +69,10 @@ defmodule ExRabbitPool.Integration.SetupQueueTest do
     )
 
     ExRabbitPool.with_channel(pool_id, fn {:ok, channel} ->
-      assert :ok = AMQP.Basic.publish(channel, "my_exchange", "", "Hello, World!")
+      assert :ok = AMQP.Basic.publish(channel, "#{queue1}_exchange", "", "Hello, World!")
       assert {:ok, "Hello, World!", _meta} = AMQP.Basic.get(channel, queue1, no_ack: true)
 
-      assert :ok = AMQP.Basic.publish(channel, "my_exchange2", "", "Hell Yeah!")
+      assert :ok = AMQP.Basic.publish(channel, "#{queue2}_exchange", "", "Hell Yeah!")
       assert {:ok, "Hell Yeah!", _meta} = AMQP.Basic.get(channel, queue2, no_ack: true)
 
       assert {:ok, _} = AMQP.Queue.delete(channel, queue1)
@@ -138,13 +138,13 @@ defmodule ExRabbitPool.Integration.SetupQueueTest do
           queues: [
             [
               queue_name: queue1,
-              exchange: "my_exchange",
+              exchange: "#{queue1}_exchange",
               queue_options: [auto_delete: true],
               exchange_options: [auto_delete: true, type: :fanout]
             ],
             [
               queue_name: queue2,
-              exchange: "my_exchange",
+              exchange: "#{queue1}_exchange",
               queue_options: [auto_delete: true],
               exchange_options: [auto_delete: true, type: :fanout]
             ]
@@ -153,7 +153,7 @@ defmodule ExRabbitPool.Integration.SetupQueueTest do
     )
 
     ExRabbitPool.with_channel(pool_id, fn {:ok, channel} ->
-      assert :ok = AMQP.Basic.publish(channel, "my_exchange", "", "Hello, World!")
+      assert :ok = AMQP.Basic.publish(channel, "#{queue1}_exchange", "", "Hello, World!")
       assert {:ok, "Hello, World!", _meta} = AMQP.Basic.get(channel, queue1, no_ack: true)
       assert {:ok, "Hello, World!", _meta} = AMQP.Basic.get(channel, queue2, no_ack: true)
       assert {:ok, _} = AMQP.Queue.delete(channel, queue1)

--- a/test/worker/rabbit_connection_test.exs
+++ b/test/worker/rabbit_connection_test.exs
@@ -30,7 +30,7 @@ defmodule ExRabbitPool.Worker.RabbitConnectionTest do
   test "creates a pool of channels by default", %{config: config} do
     pid = start_supervised!({ConnWorker, Keyword.delete(config, :channels)})
     %{channels: channels} = ConnWorker.state(pid)
-    assert length(channels) == 1000
+    assert length(channels) == 10
   end
 
   test "gets a channel and put it back", %{config: config} do


### PR DESCRIPTION
TODO: see how to set up queues when they are non-durable or `auto_delete: true` and a channel/connection crashes