### PR TITLE
[change] don't re-use channel when a client crashes

### DIFF
--- a/lib/pool_supervisor.ex
+++ b/lib/pool_supervisor.ex
@@ -1,8 +1,6 @@
 defmodule ExRabbitPool.PoolSupervisor do
   use Supervisor
 
-  alias ExRabbitPool.Worker.SetupQueue
-
   @type config :: [rabbitmq_config: keyword(), connection_pools: list()]
 
   @spec start_link(config()) :: Supervisor.on_start()

--- a/mix.exs
+++ b/mix.exs
@@ -12,7 +12,7 @@ defmodule BugsBunny.MixProject do
       organization: "esl",
       description: "RabbitMQ connection pool library",
       package: package(),
-      source_url: "https://github.com/esl/ex_rabbitmq_pool",
+      source_url: "https://github.com/esl/ex_rabbitmq_pool"
     ]
   end
 


### PR DESCRIPTION
[change] apply the same logic for replacing a channel when a client crashes
[update] some code comments