### PR TITLE
Allow `prefetch_count` when consuming a channel.

### DIFF
--- a/lib/clients/rabbitmq.ex
+++ b/lib/clients/rabbitmq.ex
@@ -11,7 +11,15 @@ defmodule ExRabbitPool.RabbitMQ do
   end
 
   @impl true
-  def consume(%Channel{} = channel, queue, consumer_pid \\ nil, options \\ []) do
+  def consume(channel, queue, consumer_pid \\ nil, options \\ [])
+
+  def consume(%Channel{} = channel, queue, consumer_pid, [prefetch_count: prefetch_count] = options) do
+    Logger.warn("[ExRabbitPool.RabbitMQ.consume] queue: #{inspect queue} setting prefetch_count to #{prefetch_count}")
+    :ok = Basic.qos(channel, prefetch_count: prefetch_count)
+    Basic.consume(channel, queue, consumer_pid, options)
+  end
+
+  def consume(%Channel{} = channel, queue, consumer_pid, options) do
     Basic.consume(channel, queue, consumer_pid, options)
   end
 

--- a/lib/consumer.ex
+++ b/lib/consumer.ex
@@ -166,7 +166,7 @@ defmodule ExRabbitPool.Consumer do
       # process and monitors it handle crashes and reconnections
       defp handle_channel_checkout(
              {:ok, %{pid: channel_pid} = channel},
-             %{config: config, queue: queue, adapter: adapter, config: config} = state
+             %{config: config, queue: queue, adapter: adapter} = state
            ) do
         config = Keyword.get(config, :options, [])
 


### PR DESCRIPTION
When starting up a consumer process this adds support for setting a
prefetch on the channel.

For example:

    children = [
      {EchoConsumer, [pool_id: :consumers_pool, queue: "echo_queue", options: [prefetch_count: 1]]},