### PR TITLE
 Allow connect to RabbitMQ using connection string

### DIFF
--- a/lib/clients/fake_rabbitmq.ex
+++ b/lib/clients/fake_rabbitmq.ex
@@ -34,12 +34,16 @@ defmodule ExRabbitPool.FakeRabbitMQ do
   end
 
   @impl true
-  def open_connection(config) do
+  def open_connection(config) when is_list(config) do
     if Keyword.get(config, :queue) == "error.queue" do
       {:error, :invalid}
     else
       {:ok, %Connection{pid: self()}}
     end
+  end
+
+  def open_connection(_config) do
+    {:ok, %Connection{pid: self()}}
   end
 
   @impl true

--- a/test/worker/rabbit_connection_test.exs
+++ b/test/worker/rabbit_connection_test.exs
@@ -24,6 +24,14 @@ defmodule ExRabbitPool.Worker.RabbitConnectionTest do
     assert length(channels) == 5
   end
 
+  test "creates a connection using uri", %{config: config} do
+    config = Keyword.put(config, :uri, "amqp://guest:guest@localhost:5672/")
+    pid = start_supervised!({ConnWorker, config})
+    %{channels: channels, connection: connection} = ConnWorker.state(pid)
+    refute is_nil(connection)
+    assert length(channels) == 10
+  end
+
   test "creates a pool of channels by default", %{config: config} do
     pid = start_supervised!({ConnWorker, Keyword.delete(config, :channels)})
     %{channels: channels} = ConnWorker.state(pid)


### PR DESCRIPTION
This PR is intended to:
- Allow to connect to RabbitMQ using connection string like "amqps://user:pass@host:port/virtual_host"