### PR TITLE
Fix dialyzer errors

### DIFF
--- a/lib/clients/adapter.ex
+++ b/lib/clients/adapter.ex
@@ -9,14 +9,15 @@ defmodule ExRabbitPool.Clients.Adapter do
               {:ok, String.t()} | AMQP.Basic.error()
   @callback cancel_consume(AMQP.Channel.t(), String.t(), keyword) ::
               {:ok, String.t()} | {:error, AMQP.Basic.error()}
-  @callback ack(AMQP.Channel.t(), String.t(), keyword()) :: :ok | AMQP.Basic.error()
-  @callback reject(AMQP.Channel.t(), String.t(), keyword()) :: :ok | AMQP.Basic.error()
+  @callback ack(AMQP.Channel.t(), AMQP.Basic.delivery_tag(), keyword()) ::
+              :ok | AMQP.Basic.error()
+  @callback reject(AMQP.Channel.t(), AMQP.Basic.delivery_tag(), keyword()) ::
+              :ok | AMQP.Basic.error()
   @callback declare_queue(AMQP.Channel.t(), AMQP.Basic.queue(), keyword()) ::
               {:ok, map()} | AMQP.Basic.error()
   @callback queue_bind(AMQP.Channel.t(), AMQP.Basic.queue(), AMQP.Basic.exchange(), keyword()) ::
               :ok | AMQP.Basic.error()
   @callback declare_exchange(AMQP.Channel.t(), AMQP.Basic.exchange(), keyword()) ::
               :ok | AMQP.Basic.error()
-  @callback qos(AMQP.Channel.t(), keyword()) ::
-              :ok | AMQP.Basic.error()
+  @callback qos(AMQP.Channel.t(), keyword()) :: :ok | AMQP.Basic.error()
 end

--- a/lib/clients/fake_rabbitmq.ex
+++ b/lib/clients/fake_rabbitmq.ex
@@ -24,12 +24,12 @@ defmodule ExRabbitPool.FakeRabbitMQ do
   end
 
   @impl true
-  def ack(_channel, _tag, _options \\ []) do
+  def ack(_channel, _delivery_tag, _options \\ []) do
     :ok
   end
 
   @impl true
-  def reject(_channel, _tag, _options \\ []) do
+  def reject(_channel, _delivery_tag, _options \\ []) do
     :ok
   end
 

--- a/lib/clients/rabbitmq.ex
+++ b/lib/clients/rabbitmq.ex
@@ -21,13 +21,13 @@ defmodule ExRabbitPool.RabbitMQ do
   end
 
   @impl true
-  def ack(%Channel{} = channel, tag, options \\ []) do
-    Basic.ack(channel, tag, options)
+  def ack(%Channel{} = channel, delivery_tag, options \\ []) do
+    Basic.ack(channel, delivery_tag, options)
   end
 
   @impl true
-  def reject(%Channel{} = channel, tag, options \\ []) do
-    Basic.reject(channel, tag, options)
+  def reject(%Channel{} = channel, delivery_tag, options \\ []) do
+    Basic.reject(channel, delivery_tag, options)
   end
 
   @impl true

--- a/lib/consumer.ex
+++ b/lib/consumer.ex
@@ -116,9 +116,6 @@ defmodule ExRabbitPool.Consumer do
 
           {:stop, reason} ->
             {:stop, reason, state}
-
-          _ ->
-            {:noreply, state}
         end
       end
 
@@ -133,9 +130,6 @@ defmodule ExRabbitPool.Consumer do
 
           {:stop, reason} ->
             {:stop, reason, state}
-
-          _ ->
-            {:noreply, state}
         end
       end
 


### PR DESCRIPTION
This includes the following

* Fix `delivery_tag` type for `ack/3` and `reject/3` in adapter callback
* Follow `basic_consume_ok/2` and `basic_deliver/3` callback contract in the consumer case clauses

I'm not sure if the last is applicable, maybe the callback return types need to be changed instead?